### PR TITLE
do not print out empty rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ function Compiler(options) {
 
 Compiler.prototype.compile = function(node){
   return node.stylesheet.rules.map(this.visit, this)
+    .filter(identity)
     .join(this.compress ? '' : '\n\n');
 };
 
@@ -134,9 +135,12 @@ Compiler.prototype.keyframe = function(node){
 
 /**
  * Visit rule node.
+ * If no selectors or no declarations, returns an empty string.
  */
 
 Compiler.prototype.rule = function(node){
+  if (!node.selectors.length || !node.declarations.length) return '';
+
   if (this.compress) {
     return node.selectors.join(',')
       + '{'
@@ -178,3 +182,11 @@ Compiler.prototype.indent = function(level) {
 
   return Array(this.level).join(this.indentation || '  ');
 };
+
+/**
+ * Identity function for filtering.
+ */
+
+function identity(x) {
+  return x
+}

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -21,4 +21,40 @@ describe('stringify(obj)', function(){
       ret.should.equal(css);
     });
   });
+
+  it('should not stringify empty selectors', function(){
+    var node = {
+      stylesheet: {
+        rules: [{
+          selectors: [],
+          declarations: [{
+            property: 'color',
+            value: 'black'
+          }]
+        }]
+      }
+    };
+
+    var ret = stringify(node);
+    ret.should.equal('');
+  });
+
+  it('should not stringify empty declarations', function(){
+    var node = {
+      stylesheet: {
+        rules: [{
+          selectors: [
+            'one',
+            'two',
+            'three'
+          ],
+          declarations: []
+        }]
+      }
+    };
+
+    var ret = stringify(node);
+    ret.should.equal('');
+  });
 });
+


### PR DESCRIPTION
if there are no selectors or no declarations in a rule, don't print it out. fixes:
#7

visionmedia/rework#53

fixes the rework issues artificially
