### PR TITLE
Add option to collect source-map data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 0.8
+  - 0.10

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(node, options){
 function Compiler(options) {
   options = options || {};
   this.compress = options.compress;
-  this.indentation = options.indent || '  ';
+  this.indentation = options.compress ? '' : options.indent || '  ';
   this.map = options.map;
   this.mapUrl = options.mapUrl;
 }

--- a/index.js
+++ b/index.js
@@ -122,10 +122,10 @@ Compiler.prototype.keyframe = function(node){
  */
 
 Compiler.prototype.rule = function(node){
-  if (this.map && node.loc) {
+  if (this.map && node.position) {
     var indent = (this.level-1) * this.indentation.length;
     this.map.push({
-      original: node.loc,
+      original: node.position.start,
       generated: {
         line: this.line,
         column: this.column + indent

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ Compiler.prototype.rule = function(node){
   if (this.map && node.loc) {
     var indent = (this.level-1) * this.indentation.length;
     this.map.push({
-      source: node.loc,
+      original: node.loc,
       generated: {
         line: this.line,
         column: this.column + indent

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function Compiler(options) {
   this.compress = options.compress;
   this.indentation = options.indent || '  ';
   this.map = options.map;
+  this.mapUrl = options.mapUrl;
 }
 
 /**
@@ -33,6 +34,7 @@ Compiler.prototype.compile = function(node){
   this.column = 1;
   this.level = 1;
   this.each(node.stylesheet.rules, this.visit);
+  if (this.mapUrl) this.out += '\n/*@ sourceMappingURL=' + this.mapUrl + ' */';
   return this.out;
 };
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Compiler(options) {
   options = options || {};
   this.compress = options.compress;
   this.indentation = options.indent;
+  this.map = options.map;
 }
 
 /**
@@ -27,8 +28,11 @@ function Compiler(options) {
  */
 
 Compiler.prototype.compile = function(node){
-  return node.stylesheet.rules.map(this.visit, this)
-    .join(this.compress ? '' : '\n\n');
+  this.out = '';
+  this.line = 1;
+  this.column = 1;
+  this.each(node.stylesheet.rules, this.visit);
+  return this.out;
 };
 
 /**
@@ -36,12 +40,12 @@ Compiler.prototype.compile = function(node){
  */
 
 Compiler.prototype.visit = function(node){
-  if (node.comment) return this.comment(node);
-  if (node.charset) return this.charset(node);
-  if (node.keyframes) return this.keyframes(node);
-  if (node.media) return this.media(node);
-  if (node.import) return this.import(node);
-  return this.rule(node);
+  if (node.comment) this.comment(node);
+  else if (node.charset) this.charset(node);
+  else if (node.keyframes) this.keyframes(node);
+  else if (node.media) this.media(node);
+  else if (node.import) this.import(node);
+  else this.rule(node);
 };
 
 /**
@@ -49,8 +53,9 @@ Compiler.prototype.visit = function(node){
  */
 
 Compiler.prototype.comment = function(node){
-  if (this.compress) return '';
-  return '/*' + node.comment + '*/';
+  if (this.compress) return;
+  this.writeln('/*' + node.comment + '*/');
+  this.line += node.comment.split(/\n/).length-1;
 };
 
 /**
@@ -58,7 +63,7 @@ Compiler.prototype.comment = function(node){
  */
 
 Compiler.prototype.import = function(node){
-  return '@import ' + node.import + ';';
+  this.write('@import ' + node.import + ';');
 };
 
 /**
@@ -66,21 +71,12 @@ Compiler.prototype.import = function(node){
  */
 
 Compiler.prototype.media = function(node){
-  if (this.compress) {
-    return '@media '
-      + node.media
-      + '{'
-      + node.rules.map(this.visit, this).join('')
-      + '}';
-  }
-
-  return '@media '
-    + node.media
-    + ' {\n'
-    + this.indent(1)
-    + node.rules.map(this.visit, this).join('\n\n')
-    + this.indent(-1)
-    + '\n}';
+  this.write('@media ' + node.media);
+  this.writeln('{', ' ');
+  this.indent(1);
+  this.each(node.rules, this.visit);
+  this.indent(-1);
+  this.writeln('}');
 };
 
 /**
@@ -88,11 +84,7 @@ Compiler.prototype.media = function(node){
  */
 
 Compiler.prototype.charset = function(node){
-  if (this.compress) {
-    return '@charset ' + node.charset + ';';
-  }
-
-  return '@charset ' + node.charset + ';\n';
+  this.writeln('@charset ' + node.charset + ';');
 };
 
 /**
@@ -100,25 +92,12 @@ Compiler.prototype.charset = function(node){
  */
 
 Compiler.prototype.keyframes = function(node){
-  if (this.compress) {
-    return '@'
-      + (node.vendor || '')
-      + 'keyframes '
-      + node.name
-      + '{'
-      + node.keyframes.map(this.keyframe, this).join('')
-      + '}';
-  }
-
-  return '@'
-    + (node.vendor || '')
-    + 'keyframes '
-    + node.name
-    + ' {\n'
-    + this.indent(1)
-    + node.keyframes.map(this.keyframe, this).join('\n')
-    + this.indent(-1)
-    + '}';
+  this.write('@' + (node.vendor || '') + 'keyframes ' + node.name);
+  this.writeln('{', ' ');
+  this.indent(1);
+  this.each(node.keyframes, this.keyframe);
+  this.indent(-1);
+  this.writeln('}');
 };
 
 /**
@@ -126,20 +105,12 @@ Compiler.prototype.keyframes = function(node){
  */
 
 Compiler.prototype.keyframe = function(node){
-  if (this.compress) {
-    return node.values.join(',')
-      + '{'
-      + node.declarations.map(this.declaration, this).join(';')
-      + '}';
-  }
-
-  return this.indent()
-    + node.values.join(', ')
-    + ' {\n'
-    + this.indent(1)
-    + node.declarations.map(this.declaration, this).join(';\n')
-    + this.indent(-1)
-    + '\n' + this.indent() + '}\n';
+  this.write(node.values.join(', '));
+  this.writeln('{', ' ');
+  this.indent(1);
+  this.declarations(node.declarations);
+  this.indent(-1);
+  this.writeln('}');
 };
 
 /**
@@ -147,33 +118,39 @@ Compiler.prototype.keyframe = function(node){
  */
 
 Compiler.prototype.rule = function(node){
-  var indent = this.indent();
-
-  if (this.compress) {
-    return node.selectors.join(',')
-      + '{'
-      + node.declarations.map(this.declaration, this).join(';')
-      + '}';
+  if (this.map && node.loc) {
+    this.map.push({
+      source: node.loc,
+      generated: {
+        line: this.line,
+        column: this.column
+      }
+    });
   }
-
-  return node.selectors.map(function(s){ return indent + s }).join(',\n')
-    + ' {\n'
-    + this.indent(1)
-    + node.declarations.map(this.declaration, this).join(';\n')
-    + this.indent(-1)
-    + '\n' + this.indent() + '}';
+  var last = node.selectors.length-1;
+  node.selectors.forEach(function(s, i){
+    this.write(s);
+    if (i == last) this.writeln('{', ' ');
+    else this.writeln(',');
+  }, this);
+  this.indent(1);
+  this.declarations(node.declarations);
+  this.indent(-1);
+  this.writeln('}');
 };
 
 /**
  * Visit declaration node.
  */
 
-Compiler.prototype.declaration = function(node){
-  if (this.compress) {
-    return node.property + ':' + node.value;
-  }
-
-  return this.indent() + node.property + ': ' + node.value;
+Compiler.prototype.declarations = function(nodes){
+  var last = nodes.length-1;
+  nodes.forEach(function(node, i) {
+    this.write(node.property + ':');
+    this.write(node.value, ' ');
+    if (i != last) this.write(';', false);
+    this.writeln();
+  }, this);
 };
 
 /**
@@ -182,11 +159,54 @@ Compiler.prototype.declaration = function(node){
 
 Compiler.prototype.indent = function(level) {
   this.level = this.level || 1;
-
-  if (null != level) {
-    this.level += level;
-    return '';
-  }
-
-  return Array(this.level).join(this.indentation || '  ');
+  this.level += level;
 };
+
+/**
+ * Invoke `fn` for each item in `nodes`.
+ */
+
+Compiler.prototype.each = function(nodes, fn){
+  var last = nodes.length-1;
+  nodes.forEach(function(node, i) {
+    fn.call(this, node);
+    if (i !== last) this.writeln();
+  }, this);
+};
+
+/**
+ * Append the given `str`.
+ * If `indent` is omitted the default indentation is applied.
+ * If `indent` is falsy `str` is append without indentation.
+ * In compression mode all indetation is ignored.
+ */
+
+Compiler.prototype.write = function(str, indent){
+  if (!this.compress) {
+    if (indent === undefined) {
+      indent = Array(this.level).join(this.indentation || '  ');
+    }
+    if (indent) {
+      this.out += indent;
+      this.column += indent.length;
+    }
+  }
+  this.out += str;
+  this.column += str.length;
+};
+
+/**
+ * Append the given `str` followed by a line break.
+ * This increases the internal line counter by one unless compression is turned
+ * on, in which case no line breaks are added.
+ */
+
+Compiler.prototype.writeln = function(str, indent){
+  if (arguments.length) this.write(str, indent);
+  if (!this.compress) {
+    this.out += '\n';
+    this.line++;
+    this.column = 1;
+  }
+};
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "mocha": "*",
     "should": "*",
-    "css-parse": "https://github.com/fgnass/css-parse/tarball/master"
+    "css-parse": "https://github.com/fgnass/css-parse/tarball/add/pos"
   },
   "main": "index"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "mocha": "*",
     "should": "*",
-    "css-parse": "1.1.0"
+    "css-parse": "https://github.com/fgnass/css-parse/tarball/master"
   },
   "main": "index"
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "CSS compiler",
   "keywords": ["css", "stringify", "stylesheet"],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --require should"
+  },
   "devDependencies": {
     "mocha": "*",
     "should": "*",

--- a/test/cases/keyframes.compress.css
+++ b/test/cases/keyframes.compress.css
@@ -1,0 +1,1 @@
+@keyframes fade{from{opacity:0;opacity:1}to{opacity:1}}

--- a/test/cases/media.compress.css
+++ b/test/cases/media.compress.css
@@ -1,0 +1,1 @@
+@media screen,projection{html{background:#fffef0;color:#300}body{max-width:35em;margin:0 auto}}@media print{html{background:#fff;color:#000}body{padding:1in;border:0.5pt solid #666}}

--- a/test/cases/rules.compress.css
+++ b/test/cases/rules.compress.css
@@ -1,0 +1,1 @@
+tobi{name:'tobi';age:2}loki{name:'loki';age:1}

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -21,8 +21,8 @@ describe('stringify(obj)', function(){
       var map = [];
       var ret = stringify(ast, { compress: compress, map: map });
       ret.trim().should.equal(css.trim());
-      map.forEach(function(loc) {
-        loc.generated.should.eql(loc.source);
+      map.forEach(function(m) {
+        m.generated.should.eql(m.original);
       });
     });
   });

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -26,4 +26,11 @@ describe('stringify(obj)', function(){
       });
     });
   });
+
+  it('should append sourceMappingURL comment', function(){
+    var ast = { stylesheet: { rules: [] }};
+    var ret = stringify(ast, { mapUrl: 'foo.map' });
+    ret.trim().should.equal('/*@ sourceMappingURL=foo.map */');
+  });
+
 });

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -22,3 +22,37 @@ describe('stringify(obj)', function(){
     });
   });
 });
+
+describe('stringify(obj, {map: []})', function(){
+  it('should generate mappings', function(){
+    var ast = { stylesheet: { rules: [
+      { selectors: ['.foo'], declarations: [], loc: { line: 2, column: 4 } },
+      { selectors: ['.bar'], declarations: [], loc: { line: 4, column: 4 } }
+    ]}};
+    var map = [];
+    stringify(ast, { map: map });
+    map.should.eql([
+      {
+        source: { line: 2, column: 4 },
+        generated: { line: 1, column: 1 }
+      },
+      {
+        source: { line: 4, column: 4 },
+        generated: { line: 4, column: 1 }
+      }
+    ]);
+
+    map = [];
+    stringify(ast, { map: map, compress: true });
+    map.should.eql([
+      {
+        source: { line: 2, column: 4 },
+        generated: { line: 1, column: 1 }
+      },
+      {
+        source: { line: 4, column: 4 },
+        generated: { line: 1, column: 7 }
+      }
+    ]);
+  });
+});

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -17,42 +17,13 @@ describe('stringify(obj)', function(){
     it('should stringify ' + file, function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
       if (compress) file = file.replace('.compress', '');
-      var ret = stringify(parse(css), { compress: compress });
+      var ast = parse(css, { loc: true });
+      var map = [];
+      var ret = stringify(ast, { compress: compress, map: map });
       ret.trim().should.equal(css.trim());
+      map.forEach(function(loc) {
+        loc.generated.should.eql(loc.source);
+      });
     });
-  });
-});
-
-describe('stringify(obj, {map: []})', function(){
-  it('should generate mappings', function(){
-    var ast = { stylesheet: { rules: [
-      { selectors: ['.foo'], declarations: [], loc: { line: 2, column: 4 } },
-      { selectors: ['.bar'], declarations: [], loc: { line: 4, column: 4 } }
-    ]}};
-    var map = [];
-    stringify(ast, { map: map });
-    map.should.eql([
-      {
-        source: { line: 2, column: 4 },
-        generated: { line: 1, column: 1 }
-      },
-      {
-        source: { line: 4, column: 4 },
-        generated: { line: 4, column: 1 }
-      }
-    ]);
-
-    map = [];
-    stringify(ast, { map: map, compress: true });
-    map.should.eql([
-      {
-        source: { line: 2, column: 4 },
-        generated: { line: 1, column: 1 }
-      },
-      {
-        source: { line: 4, column: 4 },
-        generated: { line: 1, column: 7 }
-      }
-    ]);
   });
 });

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -17,7 +17,7 @@ describe('stringify(obj)', function(){
     it('should stringify ' + file, function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
       if (compress) file = file.replace('.compress', '');
-      var ast = parse(css, { loc: true });
+      var ast = parse(css, { position: true });
       var map = [];
       var ret = stringify(ast, { compress: compress, map: map });
       ret.trim().should.equal(css.trim());


### PR DESCRIPTION
When `{ map: [] }` is passed as second argument css-stringify will populate the given array with mapping data. For each node that has a `loc` property an entry like this is added: 

``` js
{
  source: { line: 1, column: 1 },
  generated: { line: 1, column: 1}
}
```
