### PR TITLE
Fix whitespace and indentation in the Compressed compiler.

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -36,7 +36,7 @@ Compiler.prototype.visit = function(node){
  */
 
 Compiler.prototype.comment = function(node){
-  if (this.compress) return '';
+  return '';
 };
 
 /**
@@ -95,11 +95,9 @@ Compiler.prototype.namespace = function(node){
 Compiler.prototype.supports = function(node){
   return '@supports '
     + node.supports
-    + ' {\n'
-    + this.indent(1)
-    + node.rules.map(this.visit, this).join('\n\n')
-    + this.indent(-1)
-    + '\n}';
+    + '{'
+    + node.rules.map(this.visit, this).join('')
+    + '}';
 };
 
 /**
@@ -135,15 +133,13 @@ Compiler.prototype.keyframe = function(node){
 
 Compiler.prototype.page = function(node){
   var sel = node.selectors.length
-    ? node.selectors.join(', ') + ' '
+    ? node.selectors.join(', ')
     : '';
 
   return '@page ' + sel
-    + '{\n'
-    + this.indent(1)
-    + node.declarations.map(this.visit, this).join('\n')
-    + this.indent(-1)
-    + '\n}';
+    + '{'
+    + node.declarations.map(this.visit, this).join('')
+    + '}';
 };
 
 /**

--- a/test/cases/document.compressed.css
+++ b/test/cases/document.compressed.css
@@ -1,0 +1,1 @@
+@-moz-document url-prefix(){.icon-spin{height:.9em;}.btn .icon-spin{height:auto;}.icon-spin.icon-large{height:1.25em;}.btn .icon-spin.icon-large{height:.75em;}}

--- a/test/cases/media.compressed.css
+++ b/test/cases/media.compressed.css
@@ -1,0 +1,1 @@
+@media screen, projection{html{background:#fffef0;color:#300;}body{max-width:35em;margin:0 auto;}}@media print{html{background:#fff;color:#000;}body{padding:1in;border:0.5pt solid #666;}}

--- a/test/cases/page.compressed.css
+++ b/test/cases/page.compressed.css
@@ -1,0 +1,1 @@
+@page {margin:2.5cm;}@page :left{margin-left:5cm;}@page :right{margin-right:5cm;}@page :first{margin-top:8cm;}

--- a/test/cases/rules.compressed.css
+++ b/test/cases/rules.compressed.css
@@ -1,0 +1,1 @@
+tobi{name:'tobi';age:2;}loki{name:'loki';age:1;}

--- a/test/cases/selectors.compressed.css
+++ b/test/cases/selectors.compressed.css
@@ -1,0 +1,1 @@
+foo,bar,baz{color:'black';}

--- a/test/cases/supports.compressed.css
+++ b/test/cases/supports.compressed.css
@@ -1,0 +1,1 @@
+@supports (display: flex){div{display:flex;}div{something:else;}}

--- a/test/cases/supports.css
+++ b/test/cases/supports.css
@@ -1,4 +1,3 @@
-
 @supports (display: flex) {
   div {
     display: flex;

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -12,13 +12,16 @@ var stringify = require('..')
 
 describe('stringify(obj)', function(){
   readdir('test/cases').forEach(function(file){
-    var compress = ~file.indexOf('compress');
-    file = path.basename(file, '.css');
-    it('should stringify ' + file, function(){
-      var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
-      if (compress) file = file.replace('.compress', '');
+    var compress = ~file.indexOf('.compressed');
+    it('should stringify ' + path.basename(file), function(){
+      var expect;
+      if (compress) {
+        expect = read(path.join('test', 'cases', file), 'utf8');
+        file = file.replace('.compressed', '');
+      }
+      var css = read(path.join('test', 'cases', file), 'utf8');
       var ret = stringify(parse(css), { compress: compress });
-      ret.trim().should.equal(css.trim());
+      ret.trim().should.equal((expect || css).trim());
     });
   });
 });


### PR DESCRIPTION
Before this change the Compressed compiler errored when processing @page and
@supports blocks, and the tests did not cover this.

This change fixes @page and @supports compression in the Compressed compiler,
fixes the tests to fully flex the Compressed compiler, and adds missing fixtures
to flesh out the test suite.
