### PR TITLE
Initial support for source map generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(node, options){
 
   var code = compiler.compile(node);
   if (options.sourceMap)
-    return {code: code, map: compiler.map}
+    return {code: code, map: compiler.map.toJSON()}
   else
     return code;
 };

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ module.exports = function(node, options){
     ? new Compressed(options)
     : new Identity(options);
 
-  return compiler.compile(node);
+  var code = compiler.compile(node);
+  if (options.sourceMap)
+    return {code: code, map: compiler.map}
+  else
+    return code;
 };
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,11 @@ module.exports = function(node, options){
     ? new Compressed(options)
     : new Identity(options);
 
+  if (options.sourceMap) {
+    var addSourceMaps = require('./lib/source-map-support');
+    addSourceMaps(compiler);
+  }
+
   var code = compiler.compile(node);
   if (options.sourceMap)
     return {code: code, map: compiler.map.toJSON()}

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,0 +1,80 @@
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
+
+module.exports = Compiler;
+
+function Compiler(options) {
+  options = options || {};
+  this.map = new SourceMapGenerator({file: options.filename || 'generated.css'});
+  this.position = {line: 1, column: 1};
+}
+
+/**
+ * Update current position according to `str` being emitted
+ */
+Compiler.prototype.updatePosition = function(str) {
+  var lines = str.match(/\n/g);
+  if (lines) this.position.line += lines.length;
+  var i = str.lastIndexOf('\n');
+  this.position.column = ~i ? str.length - i : this.position.column + str.length;
+}
+
+/**
+ * Emit `str` and update current position, use original source `pos` to
+ * construct source mapping.
+ */
+
+Compiler.prototype.emit = function(str, pos, startOnly) {
+  if (pos && pos.start) {
+    this.map.addMapping({
+      generated: {
+        line: this.position.line,
+        column: Math.max(this.position.column - 1, 0)
+      },
+      source: 'source.css',
+      original: {
+        line: pos.start.line,
+        column: pos.start.column - 1
+      }
+    });
+  }
+
+  this.updatePosition(str);
+
+  if (!startOnly && pos && pos.end) {
+    this.map.addMapping({
+      generated: {
+        line: this.position.line,
+        column: Math.max(this.position.column - 1, 0)
+      },
+      source: 'source.css',
+      original: {
+        line: pos.end.line,
+        column: pos.end.column - 1
+      }
+    });
+  }
+
+  return str;
+}
+
+
+/**
+ * Visit `node`.
+ */
+
+Compiler.prototype.visit = function(node){
+  return this[node.type](node);
+};
+
+/**
+ * Map visit over array of `nodes`, optionally using a `delim`
+ */
+Compiler.prototype.mapVisit = function(nodes, delim){
+  delim = delim || '';
+  var result = '';
+  for (var i = 0, length = nodes.length; i < length; i++) {
+    result += this.visit(nodes[i]);
+    if (delim && i < length - 1) result += this.emit(delim);
+  }
+  return result;
+};

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -46,7 +46,7 @@ Compiler.prototype.emit = function(str, pos, startOnly) {
         line: this.position.line,
         column: Math.max(this.position.column - 1, 0)
       },
-      source: 'source.css',
+      source: pos.source || 'source.css',
       original: {
         line: pos.end.line,
         column: pos.end.column - 1

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,62 +1,16 @@
-var SourceMapGenerator = require('source-map').SourceMapGenerator;
 
 module.exports = Compiler;
 
 function Compiler(options) {
-  options = options || {};
-  this.map = new SourceMapGenerator({file: options.filename || 'generated.css'});
-  this.position = {line: 1, column: 1};
+  this.options = options || {};
 }
 
 /**
- * Update current position according to `str` being emitted
+ * Emit `str`
  */
-Compiler.prototype.updatePosition = function(str) {
-  var lines = str.match(/\n/g);
-  if (lines) this.position.line += lines.length;
-  var i = str.lastIndexOf('\n');
-  this.position.column = ~i ? str.length - i : this.position.column + str.length;
-}
-
-/**
- * Emit `str` and update current position, use original source `pos` to
- * construct source mapping.
- */
-
 Compiler.prototype.emit = function(str, pos, startOnly) {
-  if (pos && pos.start) {
-    this.map.addMapping({
-      generated: {
-        line: this.position.line,
-        column: Math.max(this.position.column - 1, 0)
-      },
-      source: pos.source || 'source.css',
-      original: {
-        line: pos.start.line,
-        column: pos.start.column - 1
-      }
-    });
-  }
-
-  this.updatePosition(str);
-
-  if (!startOnly && pos && pos.end) {
-    this.map.addMapping({
-      generated: {
-        line: this.position.line,
-        column: Math.max(this.position.column - 1, 0)
-      },
-      source: pos.source || 'source.css',
-      original: {
-        line: pos.end.line,
-        column: pos.end.column - 1
-      }
-    });
-  }
-
   return str;
 }
-
 
 /**
  * Visit `node`.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -30,7 +30,7 @@ Compiler.prototype.emit = function(str, pos, startOnly) {
         line: this.position.line,
         column: Math.max(this.position.column - 1, 0)
       },
-      source: 'source.css',
+      source: pos.source || 'source.css',
       original: {
         line: pos.start.line,
         column: pos.start.column - 1

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1,4 +1,4 @@
-var SourceMapGenerator = require('source-map').SourceMapGenerator;
+var CompilerBase = require('./compiler');
 
 /**
  * Expose compiler.
@@ -11,55 +11,10 @@ module.exports = Compiler;
  */
 
 function Compiler(options) {
-  options = options || {};
-  this.map = new SourceMapGenerator({file: options.filename || 'generated.css'});
-  this.position = {line: 1, column: 1};
+  CompilerBase.call(this, options);
 }
 
-Compiler.prototype.updatePosition = function(str) {
-  var lines = str.match(/\n/g);
-  if (lines) this.position.line += lines.length;
-  var i = str.lastIndexOf('\n');
-  this.position.column = ~i ? str.length - i : this.position.column + str.length;
-}
-
-/**
- * Emit string and update current position
- */
-
-Compiler.prototype.emit = function(str, pos, startOnly) {
-  if (pos && pos.start) {
-    this.map.addMapping({
-      generated: {
-        line: this.position.line,
-        column: Math.max(this.position.column - 1, 0)
-      },
-      source: 'source.css',
-      original: {
-        line: pos.start.line,
-        column: pos.start.column - 1
-      }
-    });
-  }
-
-  this.updatePosition(str);
-
-  if (!startOnly && pos && pos.end) {
-    this.map.addMapping({
-      generated: {
-        line: this.position.line,
-        column: Math.max(this.position.column - 1, 0)
-      },
-      source: 'source.css',
-      original: {
-        line: pos.end.line,
-        column: pos.end.column - 1
-      }
-    });
-  }
-
-  return str;
-}
+Compiler.prototype = new CompilerBase();
 
 /**
  * Compile `node`.
@@ -69,24 +24,6 @@ Compiler.prototype.compile = function(node){
   return node.stylesheet
     .rules.map(this.visit, this)
     .join('');
-};
-
-/**
- * Visit `node`.
- */
-
-Compiler.prototype.visit = function(node){
-  return this[node.type](node);
-};
-
-Compiler.prototype.visitMap = function(nodes, join){
-  join = join || '';
-  var result = '';
-  for (var i = 0, length = nodes.length; i < length; i++) {
-    result += this.visit(nodes[i]);
-    if (i < length - 1) result += this.emit(join);
-  }
-  return result;
 };
 
 /**
@@ -112,7 +49,7 @@ Compiler.prototype.import = function(node){
 Compiler.prototype.media = function(node){
   return this.emit('@media ' + node.media, node.position, true)
     + this.emit('{')
-    + this.visitMap(node.rules)
+    + this.mapVisit(node.rules)
     + this.emit('}');
 };
 
@@ -125,7 +62,7 @@ Compiler.prototype.document = function(node){
 
   return this.emit(doc, node.position, true)
     + this.emit('{')
-    + this.visitMap(node.rules)
+    + this.mapVisit(node.rules)
     + this.emit('}');
 };
 
@@ -152,7 +89,7 @@ Compiler.prototype.namespace = function(node){
 Compiler.prototype.supports = function(node){
   return this.emit('@supports ' + node.supports, node.position, true)
     + this.emit('{')
-    + this.visitMap(node.rules)
+    + this.mapVisit(node.rules)
     + this.emit('}');
 };
 
@@ -166,7 +103,7 @@ Compiler.prototype.keyframes = function(node){
     + 'keyframes '
     + node.name, node.position, true)
     + this.emit('{')
-    + this.visitMap(node.keyframes)
+    + this.mapVisit(node.keyframes)
     + this.emit('}');
 };
 
@@ -179,7 +116,7 @@ Compiler.prototype.keyframe = function(node){
 
   return this.emit(node.values.join(','), node.position, true)
     + this.emit('{')
-    + this.visitMap(decls)
+    + this.mapVisit(decls)
     + this.emit('}');
 };
 
@@ -194,7 +131,7 @@ Compiler.prototype.page = function(node){
 
   return this.emit('@page ' + sel, node.position, true)
     + this.emit('{')
-    + this.visitMap(node.declarations)
+    + this.mapVisit(node.declarations)
     + this.emit('}');
 };
 
@@ -208,7 +145,7 @@ Compiler.prototype.rule = function(node){
 
   return this.emit(node.selectors.join(','), node.position, true)
     + this.emit('{')
-    + this.visitMap(decls)
+    + this.mapVisit(decls)
     + this.emit('}');
 };
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1,3 +1,4 @@
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
 
 /**
  * Expose compiler.
@@ -11,6 +12,53 @@ module.exports = Compiler;
 
 function Compiler(options) {
   options = options || {};
+  this.map = new SourceMapGenerator({file: options.filename || 'generated.css'});
+  this.position = {line: 1, column: 1};
+}
+
+Compiler.prototype.updatePosition = function(str) {
+  var lines = str.match(/\n/g);
+  if (lines) this.position.line += lines.length;
+  var i = str.lastIndexOf('\n');
+  this.position.column = ~i ? str.length - i : this.position.column + str.length;
+}
+
+/**
+ * Emit string and update current position
+ */
+
+Compiler.prototype.emit = function(str, pos, startOnly) {
+  if (pos && pos.start) {
+    this.map.addMapping({
+      generated: {
+        line: this.position.line,
+        column: Math.max(this.position.column - 1, 0)
+      },
+      source: 'source.css',
+      original: {
+        line: pos.start.line,
+        column: pos.start.column - 1
+      }
+    });
+  }
+
+  this.updatePosition(str);
+
+  if (!startOnly && pos && pos.end) {
+    this.map.addMapping({
+      generated: {
+        line: this.position.line,
+        column: Math.max(this.position.column - 1, 0)
+      },
+      source: 'source.css',
+      original: {
+        line: pos.end.line,
+        column: pos.end.column - 1
+      }
+    });
+  }
+
+  return str;
 }
 
 /**
@@ -31,12 +79,22 @@ Compiler.prototype.visit = function(node){
   return this[node.type](node);
 };
 
+Compiler.prototype.visitMap = function(nodes, join){
+  join = join || '';
+  var result = '';
+  for (var i = 0, length = nodes.length; i < length; i++) {
+    result += this.visit(nodes[i]);
+    if (i < length - 1) result += this.emit(join);
+  }
+  return result;
+};
+
 /**
  * Visit comment node.
  */
 
 Compiler.prototype.comment = function(node){
-  return '';
+  return this.emit('', node.position);
 };
 
 /**
@@ -44,7 +102,7 @@ Compiler.prototype.comment = function(node){
  */
 
 Compiler.prototype.import = function(node){
-  return '@import ' + node.import + ';';
+  return this.emit('@import ' + node.import + ';', node.position);
 };
 
 /**
@@ -52,11 +110,10 @@ Compiler.prototype.import = function(node){
  */
 
 Compiler.prototype.media = function(node){
-  return '@media '
-    + node.media
-    + '{'
-    + node.rules.map(this.visit, this).join('')
-    + '}';
+  return this.emit('@media ' + node.media, node.position, true)
+    + this.emit('{')
+    + this.visitMap(node.rules)
+    + this.emit('}');
 };
 
 /**
@@ -66,10 +123,10 @@ Compiler.prototype.media = function(node){
 Compiler.prototype.document = function(node){
   var doc = '@' + (node.vendor || '') + 'document ' + node.document;
 
-  return doc
-    + '{'
-    + node.rules.map(this.visit, this).join('')
-    + '}';
+  return this.emit(doc, node.position, true)
+    + this.emit('{')
+    + this.visitMap(node.rules)
+    + this.emit('}');
 };
 
 /**
@@ -77,7 +134,7 @@ Compiler.prototype.document = function(node){
  */
 
 Compiler.prototype.charset = function(node){
-  return '@charset ' + node.charset + ';';
+  return this.emit('@charset ' + node.charset + ';', node.position);
 };
 
 /**
@@ -85,7 +142,7 @@ Compiler.prototype.charset = function(node){
  */
 
 Compiler.prototype.namespace = function(node){
-  return '@namespace ' + node.namespace + ';';
+  return this.emit('@namespace ' + node.namespace + ';', node.position);
 };
 
 /**
@@ -93,11 +150,10 @@ Compiler.prototype.namespace = function(node){
  */
 
 Compiler.prototype.supports = function(node){
-  return '@supports '
-    + node.supports
-    + '{'
-    + node.rules.map(this.visit, this).join('')
-    + '}';
+  return this.emit('@supports ' + node.supports, node.position, true)
+    + this.emit('{')
+    + this.visitMap(node.rules)
+    + this.emit('}');
 };
 
 /**
@@ -105,13 +161,13 @@ Compiler.prototype.supports = function(node){
  */
 
 Compiler.prototype.keyframes = function(node){
-  return '@'
+  return this.emit('@'
     + (node.vendor || '')
     + 'keyframes '
-    + node.name
-    + '{'
-    + node.keyframes.map(this.visit, this).join('')
-    + '}';
+    + node.name, node.position, true)
+    + this.emit('{')
+    + this.visitMap(node.keyframes)
+    + this.emit('}');
 };
 
 /**
@@ -121,10 +177,10 @@ Compiler.prototype.keyframes = function(node){
 Compiler.prototype.keyframe = function(node){
   var decls = node.declarations;
 
-  return node.values.join(',')
-    + '{'
-    + decls.map(this.visit, this).join('')
-    + '}';
+  return this.emit(node.values.join(','), node.position, true)
+    + this.emit('{')
+    + this.visitMap(decls)
+    + this.emit('}');
 };
 
 /**
@@ -136,10 +192,10 @@ Compiler.prototype.page = function(node){
     ? node.selectors.join(', ')
     : '';
 
-  return '@page ' + sel
-    + '{'
-    + node.declarations.map(this.visit, this).join('')
-    + '}';
+  return this.emit('@page ' + sel, node.position, true)
+    + this.emit('{')
+    + this.visitMap(node.declarations)
+    + this.emit('}');
 };
 
 /**
@@ -150,10 +206,10 @@ Compiler.prototype.rule = function(node){
   var decls = node.declarations;
   if (!decls.length) return '';
 
-  return node.selectors.join(',')
-    + '{'
-    + decls.map(this.visit, this).join('')
-    + '}';
+  return this.emit(node.selectors.join(','), node.position, true)
+    + this.emit('{')
+    + this.visitMap(decls)
+    + this.emit('}');
 };
 
 /**
@@ -161,6 +217,6 @@ Compiler.prototype.rule = function(node){
  */
 
 Compiler.prototype.declaration = function(node){
-  return node.property + ':' + node.value + ';';
+  return this.emit(node.property + ':' + node.value, node.position) + this.emit(';');
 };
 

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -17,16 +17,16 @@ function Compiler(options) {
   this.indentation = options.indent;
 }
 
-/**
- * Emit string and update current position
- */
-
 Compiler.prototype.updatePosition = function(str) {
   var lines = str.match(/\n/g);
   if (lines) this.position.line += lines.length;
   var i = str.lastIndexOf('\n');
   this.position.column = ~i ? str.length - i : this.position.column + str.length;
 }
+
+/**
+ * Emit string and update current position
+ */
 
 Compiler.prototype.emit = function(str, pos, startOnly) {
   if (pos && pos.start) {
@@ -250,9 +250,7 @@ Compiler.prototype.rule = function(node){
 
 Compiler.prototype.declaration = function(node){
   return this.emit(this.indent())
-    + this.emit(node.property, node.position)
-    + this.emit(': ')
-    + this.emit(node.value, node.position)
+    + this.emit(node.property + ': ' + node.value, node.position)
     + this.emit(';');
 };
 

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -1,3 +1,4 @@
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
 
 /**
  * Expose compiler.
@@ -11,7 +12,54 @@ module.exports = Compiler;
 
 function Compiler(options) {
   options = options || {};
+  this.map = new SourceMapGenerator({file: options.filename || 'generated.css'});
+  this.position = {line: 1, column: 0};
   this.indentation = options.indent;
+}
+
+/**
+ * Emit string and update current position
+ */
+
+Compiler.prototype.updatePosition = function(str) {
+  var lines = str.match(/\n/g);
+  if (lines) this.position.line += lines.length;
+  var i = str.lastIndexOf('\n');
+  this.position.column = ~i ? str.length - i : this.position.column + str.length;
+}
+
+Compiler.prototype.emit = function(str, pos, startOnly) {
+  if (pos && pos.start) {
+    this.map.addMapping({
+      generated: {
+        line: this.position.line,
+        column: Math.max(this.position.column - 1, 0)
+      },
+      source: 'source.css',
+      original: {
+        line: pos.start.line,
+        column: pos.start.column - 1
+      }
+    });
+  }
+
+  this.updatePosition(str);
+
+  if (!startOnly && pos && pos.end) {
+    this.map.addMapping({
+      generated: {
+        line: this.position.line,
+        column: Math.max(this.position.column - 1, 0)
+      },
+      source: 'source.css',
+      original: {
+        line: pos.end.line,
+        column: pos.end.column - 1
+      }
+    });
+  }
+
+  return str;
 }
 
 /**
@@ -30,14 +78,22 @@ Compiler.prototype.visit = function(node){
   return this[node.type](node);
 };
 
+Compiler.prototype.visitMap = function(nodes, join){
+  join = join || '';
+  var result = '';
+  for (var i = 0, length = nodes.length; i < length; i++) {
+    result += this.visit(nodes[i]);
+    if (i < length - 1) result += this.emit(join);
+  }
+  return result;
+};
+
 /**
  * Visit stylesheet node.
  */
 
 Compiler.prototype.stylesheet = function(node){
-  return node.stylesheet
-    .rules.map(this.visit, this)
-    .join('\n\n');
+  return this.visitMap(node.stylesheet.rules, '\n\n');
 };
 
 /**
@@ -45,7 +101,7 @@ Compiler.prototype.stylesheet = function(node){
  */
 
 Compiler.prototype.comment = function(node){
-  return this.indent() + '/*' + node.comment + '*/';
+  return this.emit(this.indent() + '/*' + node.comment + '*/', node.position);
 };
 
 /**
@@ -53,7 +109,7 @@ Compiler.prototype.comment = function(node){
  */
 
 Compiler.prototype.import = function(node){
-  return '@import ' + node.import + ';';
+  return this.emit('@import ' + node.import + ';', node.position);
 };
 
 /**
@@ -61,13 +117,14 @@ Compiler.prototype.import = function(node){
  */
 
 Compiler.prototype.media = function(node){
-  return '@media '
-    + node.media
-    + ' {\n'
-    + this.indent(1)
-    + node.rules.map(this.visit, this).join('\n\n')
-    + this.indent(-1)
-    + '\n}';
+  return this.emit('@media ' + node.media, node.position, true)
+    + this.emit(
+        ' {\n'
+        + this.indent(1))
+    + this.visitMap(node.rules, '\n\n')
+    + this.emit(
+        this.indent(-1)
+        + '\n}');
 };
 
 /**
@@ -77,12 +134,15 @@ Compiler.prototype.media = function(node){
 Compiler.prototype.document = function(node){
   var doc = '@' + (node.vendor || '') + 'document ' + node.document;
 
-  return doc + ' '
-    + ' {\n'
-    + this.indent(1)
-    + node.rules.map(this.visit, this).join('\n\n')
-    + this.indent(-1)
-    + '\n}';
+  return this.emit(doc, node.position, true)
+    + this.emit(
+        ' '
+      + ' {\n'
+      + this.indent(1))
+    + this.visitMap(node.rules, '\n\n')
+    + this.emit(
+        this.indent(-1)
+        + '\n}');
 };
 
 /**
@@ -90,7 +150,7 @@ Compiler.prototype.document = function(node){
  */
 
 Compiler.prototype.charset = function(node){
-  return '@charset ' + node.charset + ';\n';
+  return this.emit('@charset ' + node.charset + ';', node.position);
 };
 
 /**
@@ -98,7 +158,7 @@ Compiler.prototype.charset = function(node){
  */
 
 Compiler.prototype.namespace = function(node){
-  return '@namespace ' + node.namespace + ';\n';
+  return this.emit('@namespace ' + node.namespace + ';', node.position);
 };
 
 /**
@@ -106,13 +166,14 @@ Compiler.prototype.namespace = function(node){
  */
 
 Compiler.prototype.supports = function(node){
-  return '@supports '
-    + node.supports
-    + ' {\n'
-    + this.indent(1)
-    + node.rules.map(this.visit, this).join('\n\n')
-    + this.indent(-1)
-    + '\n}';
+  return this.emit('@supports ' + node.supports, node.position, true)
+    + this.emit(
+      ' {\n'
+      + this.indent(1))
+    + this.visitMap(node.rules, '\n\n')
+    + this.emit(
+        this.indent(-1)
+        + '\n}');
 };
 
 /**
@@ -120,15 +181,14 @@ Compiler.prototype.supports = function(node){
  */
 
 Compiler.prototype.keyframes = function(node){
-  return '@'
-    + (node.vendor || '')
-    + 'keyframes '
-    + node.name
-    + ' {\n'
-    + this.indent(1)
-    + node.keyframes.map(this.visit, this).join('\n')
-    + this.indent(-1)
-    + '}';
+  return this.emit('@' + (node.vendor || '') + 'keyframes ' + node.name, node.position, true)
+    + this.emit(
+      ' {\n'
+      + this.indent(1))
+    + this.visitMap(node.keyframes, '\n')
+    + this.emit(
+        this.indent(-1)
+        + '}');
 };
 
 /**
@@ -138,13 +198,16 @@ Compiler.prototype.keyframes = function(node){
 Compiler.prototype.keyframe = function(node){
   var decls = node.declarations;
 
-  return this.indent()
-    + node.values.join(', ')
-    + ' {\n'
-    + this.indent(1)
-    + decls.map(this.visit, this).join('\n')
-    + this.indent(-1)
-    + '\n' + this.indent() + '}\n';
+  return this.emit(this.indent())
+    + this.emit(node.values.join(', '), node.position, true)
+    + this.emit(
+      ' {\n'
+      + this.indent(1))
+    + this.visitMap(decls, '\n')
+    + this.emit(
+      this.indent(-1)
+      + '\n'
+      + this.indent() + '}\n');
 };
 
 /**
@@ -156,12 +219,12 @@ Compiler.prototype.page = function(node){
     ? node.selectors.join(', ') + ' '
     : '';
 
-  return '@page ' + sel
-    + '{\n'
-    + this.indent(1)
-    + node.declarations.map(this.visit, this).join('\n')
-    + this.indent(-1)
-    + '\n}';
+  return this.emit('@page ' + sel, node.position, true)
+    + this.emit('{\n')
+    + this.emit(this.indent(1))
+    + this.visitMap(node.declarations, '\n')
+    + this.emit(this.indent(-1))
+    + this.emit('\n}');
 };
 
 /**
@@ -173,12 +236,12 @@ Compiler.prototype.rule = function(node){
   var decls = node.declarations;
   if (!decls.length) return '';
 
-  return node.selectors.map(function(s){ return indent + s }).join(',\n')
-    + ' {\n'
-    + this.indent(1)
-    + decls.map(this.visit, this).join('\n')
-    + this.indent(-1)
-    + '\n' + this.indent() + '}';
+  return this.emit(node.selectors.map(function(s){ return indent + s }).join(',\n'), node.position, true)
+    + this.emit(' {\n')
+    + this.emit(this.indent(1))
+    + this.visitMap(decls, '\n')
+    + this.emit(this.indent(-1))
+    + this.emit('\n' + this.indent() + '}');
 };
 
 /**
@@ -186,7 +249,11 @@ Compiler.prototype.rule = function(node){
  */
 
 Compiler.prototype.declaration = function(node){
-  return this.indent() + node.property + ': ' + node.value + ';';
+  return this.emit(this.indent())
+    + this.emit(node.property, node.position)
+    + this.emit(': ')
+    + this.emit(node.value, node.position)
+    + this.emit(';');
 };
 
 /**

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -1,4 +1,4 @@
-var SourceMapGenerator = require('source-map').SourceMapGenerator;
+var CompilerBase = require('./compiler');
 
 /**
  * Expose compiler.
@@ -12,55 +12,11 @@ module.exports = Compiler;
 
 function Compiler(options) {
   options = options || {};
-  this.map = new SourceMapGenerator({file: options.filename || 'generated.css'});
-  this.position = {line: 1, column: 0};
+  CompilerBase.call(this, options);
   this.indentation = options.indent;
 }
 
-Compiler.prototype.updatePosition = function(str) {
-  var lines = str.match(/\n/g);
-  if (lines) this.position.line += lines.length;
-  var i = str.lastIndexOf('\n');
-  this.position.column = ~i ? str.length - i : this.position.column + str.length;
-}
-
-/**
- * Emit string and update current position
- */
-
-Compiler.prototype.emit = function(str, pos, startOnly) {
-  if (pos && pos.start) {
-    this.map.addMapping({
-      generated: {
-        line: this.position.line,
-        column: Math.max(this.position.column - 1, 0)
-      },
-      source: 'source.css',
-      original: {
-        line: pos.start.line,
-        column: pos.start.column - 1
-      }
-    });
-  }
-
-  this.updatePosition(str);
-
-  if (!startOnly && pos && pos.end) {
-    this.map.addMapping({
-      generated: {
-        line: this.position.line,
-        column: Math.max(this.position.column - 1, 0)
-      },
-      source: 'source.css',
-      original: {
-        line: pos.end.line,
-        column: pos.end.column - 1
-      }
-    });
-  }
-
-  return str;
-}
+Compiler.prototype = new CompilerBase;
 
 /**
  * Compile `node`.
@@ -71,29 +27,11 @@ Compiler.prototype.compile = function(node){
 };
 
 /**
- * Visit `node`.
- */
-
-Compiler.prototype.visit = function(node){
-  return this[node.type](node);
-};
-
-Compiler.prototype.visitMap = function(nodes, join){
-  join = join || '';
-  var result = '';
-  for (var i = 0, length = nodes.length; i < length; i++) {
-    result += this.visit(nodes[i]);
-    if (i < length - 1) result += this.emit(join);
-  }
-  return result;
-};
-
-/**
  * Visit stylesheet node.
  */
 
 Compiler.prototype.stylesheet = function(node){
-  return this.visitMap(node.stylesheet.rules, '\n\n');
+  return this.mapVisit(node.stylesheet.rules, '\n\n');
 };
 
 /**
@@ -121,7 +59,7 @@ Compiler.prototype.media = function(node){
     + this.emit(
         ' {\n'
         + this.indent(1))
-    + this.visitMap(node.rules, '\n\n')
+    + this.mapVisit(node.rules, '\n\n')
     + this.emit(
         this.indent(-1)
         + '\n}');
@@ -139,7 +77,7 @@ Compiler.prototype.document = function(node){
         ' '
       + ' {\n'
       + this.indent(1))
-    + this.visitMap(node.rules, '\n\n')
+    + this.mapVisit(node.rules, '\n\n')
     + this.emit(
         this.indent(-1)
         + '\n}');
@@ -170,7 +108,7 @@ Compiler.prototype.supports = function(node){
     + this.emit(
       ' {\n'
       + this.indent(1))
-    + this.visitMap(node.rules, '\n\n')
+    + this.mapVisit(node.rules, '\n\n')
     + this.emit(
         this.indent(-1)
         + '\n}');
@@ -185,7 +123,7 @@ Compiler.prototype.keyframes = function(node){
     + this.emit(
       ' {\n'
       + this.indent(1))
-    + this.visitMap(node.keyframes, '\n')
+    + this.mapVisit(node.keyframes, '\n')
     + this.emit(
         this.indent(-1)
         + '}');
@@ -203,7 +141,7 @@ Compiler.prototype.keyframe = function(node){
     + this.emit(
       ' {\n'
       + this.indent(1))
-    + this.visitMap(decls, '\n')
+    + this.mapVisit(decls, '\n')
     + this.emit(
       this.indent(-1)
       + '\n'
@@ -222,7 +160,7 @@ Compiler.prototype.page = function(node){
   return this.emit('@page ' + sel, node.position, true)
     + this.emit('{\n')
     + this.emit(this.indent(1))
-    + this.visitMap(node.declarations, '\n')
+    + this.mapVisit(node.declarations, '\n')
     + this.emit(this.indent(-1))
     + this.emit('\n}');
 };
@@ -239,7 +177,7 @@ Compiler.prototype.rule = function(node){
   return this.emit(node.selectors.map(function(s){ return indent + s }).join(',\n'), node.position, true)
     + this.emit(' {\n')
     + this.emit(this.indent(1))
-    + this.visitMap(decls, '\n')
+    + this.mapVisit(decls, '\n')
     + this.emit(this.indent(-1))
     + this.emit('\n' + this.indent() + '}');
 };

--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -1,0 +1,61 @@
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
+
+module.exports = mixin;
+
+/**
+ * Mixin source map support into the `compiler`
+ */
+function mixin(compiler) {
+  compiler.map = new SourceMapGenerator({file: compiler.options.filename || 'generated.css'});
+  compiler.position = {line: 1, column: 1};
+
+  for (var k in SourceMapSupport) {
+    compiler[k] = SourceMapSupport[k];
+  }
+}
+
+/**
+ * Compiler mixin which adds source map support
+ */
+var SourceMapSupport = {
+  updatePosition: function(str) {
+    var lines = str.match(/\n/g);
+    if (lines) this.position.line += lines.length;
+    var i = str.lastIndexOf('\n');
+    this.position.column = ~i ? str.length - i : this.position.column + str.length;
+  },
+
+  emit: function(str, pos, startOnly) {
+    if (pos && pos.start) {
+      this.map.addMapping({
+        generated: {
+          line: this.position.line,
+          column: Math.max(this.position.column - 1, 0)
+        },
+        source: pos.source || 'source.css',
+        original: {
+          line: pos.start.line,
+          column: pos.start.column - 1
+        }
+      });
+    }
+
+    this.updatePosition(str);
+
+    if (!startOnly && pos && pos.end) {
+      this.map.addMapping({
+        generated: {
+          line: this.position.line,
+          column: Math.max(this.position.column - 1, 0)
+        },
+        source: pos.source || 'source.css',
+        original: {
+          line: pos.end.line,
+          column: pos.end.column - 1
+        }
+      });
+    }
+
+    return str;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "scripts": {
     "test": "make test"
+  },
+  "dependencies": {
+    "source-map": "~0.1.31"
   }
 }


### PR DESCRIPTION
This is related to visionmedia/rework#109.

Ok, this is just an initial support. I think it's time to try to get the API right, currently it adds `sourceMap` option which changes the returned value to `{code: "...", map: {...}}`.
