### PR TITLE
Add support for @font-face, which should not be considered a selector

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -145,6 +145,17 @@ Compiler.prototype.page = function(node){
 };
 
 /**
+ * Visit font-face node.
+ */
+
+Compiler.prototype['font-face'] = function(node){
+  return this.emit('@font-face', node.position, true)
+    + this.emit('{')
+    + this.mapVisit(node.declarations)
+    + this.emit('}');
+};
+
+/**
  * Visit rule node.
  */
 

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -175,6 +175,19 @@ Compiler.prototype.page = function(node){
 };
 
 /**
+ * Visit font-face node.
+ */
+
+Compiler.prototype['font-face'] = function(node){
+  return this.emit('@font-face ', node.position, true)
+    + this.emit('{\n')
+    + this.emit(this.indent(1))
+    + this.mapVisit(node.declarations, '\n')
+    + this.emit(this.indent(-1))
+    + this.emit('\n}');
+};
+
+/**
  * Visit rule node.
  */
 

--- a/test/cases/font-face.compressed.css
+++ b/test/cases/font-face.compressed.css
@@ -1,0 +1,1 @@
+@font-face{font-family:"Bitstream Vera Serif Bold";src:url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");}body{font-family:"Bitstream Vera Serif Bold", serif;}

--- a/test/cases/font-face.css
+++ b/test/cases/font-face.css
@@ -1,0 +1,8 @@
+@font-face {
+  font-family: "Bitstream Vera Serif Bold";
+  src: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+}
+
+body {
+  font-family: "Bitstream Vera Serif Bold", serif;
+}


### PR DESCRIPTION
This change stringifies `@font-face` at-rules, instead of treating them as a standard rule with `@font-face` being the selector.

Requires reworkcss/css-parse#75 for tests to pass.
