### PR TITLE
Embed source file content in source map

### DIFF
--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -50,9 +50,11 @@ exports.updatePosition = function(str) {
  */
 
 exports.emit = function(str, pos, startOnly) {
+  var sourceFile = pos && pos.source || 'source.css';
+
   if (pos && pos.start) {
     this.map.addMapping({
-      source: pos.source || 'source.css',
+      source: sourceFile,
       generated: {
         line: this.position.line,
         column: Math.max(this.position.column - 1, 0)
@@ -62,13 +64,15 @@ exports.emit = function(str, pos, startOnly) {
         column: pos.start.column - 1
       }
     });
+
+    this.map.setSourceContent(sourceFile, pos.content || '');
   }
 
   this.updatePosition(str);
 
   if (!startOnly && pos && pos.end) {
     this.map.addMapping({
-      source: pos.source || 'source.css',
+      source: sourceFile,
       generated: {
         line: this.position.line,
         column: Math.max(this.position.column - 1, 0)
@@ -78,6 +82,8 @@ exports.emit = function(str, pos, startOnly) {
         column: pos.end.column - 1
       }
     });
+
+    this.map.setSourceContent(sourceFile, pos.content || '');
   }
 
   return str;

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -54,6 +54,7 @@ describe('stringify(obj, {sourcemap: true})', function(){
     map.originalPositionFor({ line: 11, column: 0 }).should.eql(locs.mediaBlock);
     map.originalPositionFor({ line: 12, column: 2 }).should.eql(locs.mediaOnly);
     map.originalPositionFor({ line: 17, column: 0 }).should.eql(locs.comment);
+    map.sourceContentFor('rules.css').should.eql(src);
   });
 
   it('should generate source maps alongside when using compress compiler', function(){
@@ -66,5 +67,6 @@ describe('stringify(obj, {sourcemap: true})', function(){
     map.originalPositionFor({ line: 1, column: 10 }).should.eql(locs.tobiNameValue);
     map.originalPositionFor({ line: 1, column: 50 }).should.eql(locs.mediaBlock);
     map.originalPositionFor({ line: 1, column: 64 }).should.eql(locs.mediaOnly);
+    map.sourceContentFor('rules.css').should.eql(src);
   });
 });


### PR DESCRIPTION
Depends on latest (currently unreleased) css-parse git master.

This adds the source file contents to the source map, like browserify and most other bundling tools do. Browser dev tools no longer have to access the original source files over HTTP, they can just pull them out of the source map.
