### PR TITLE
Apply original source maps from source files

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,10 @@ module.exports = function(node, options){
     sourcemaps(compiler);
 
     var code = compiler.compile(node);
+    compiler.applySourceMaps();
     return { code: code, map: compiler.map.toJSON() };
   }
 
   var code = compiler.compile(node);
   return code;
 };
-

--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -4,6 +4,9 @@
  */
 
 var SourceMap = require('source-map').SourceMapGenerator;
+var SourceMapConsumer = require('source-map').SourceMapConsumer;
+var sourceMapResolve = require('source-map-resolve');
+var fs = require('fs');
 
 /**
  * Expose `mixin()`.
@@ -20,8 +23,10 @@ module.exports = mixin;
 
 function mixin(compiler) {
   var file = compiler.options.filename || 'generated.css';
+  compiler._comment = compiler.comment;
   compiler.map = new SourceMap({ file: file });
   compiler.position = { line: 1, column: 1 };
+  compiler.files = {};
   for (var k in exports) compiler[k] = exports[k];
 }
 
@@ -62,6 +67,7 @@ exports.emit = function(str, pos, startOnly) {
         column: pos.start.column - 1
       }
     });
+    this.addFile(pos);
   }
 
   this.updatePosition(str);
@@ -78,7 +84,46 @@ exports.emit = function(str, pos, startOnly) {
         column: pos.end.column - 1
       }
     });
+    this.addFile(pos);
   }
 
   return str;
+};
+
+/**
+ * Adds a file to the source map output if it has not already been added
+ * @param {Object} pos
+ */
+
+exports.addFile = function(pos) {
+  var file = pos.source || 'source.css';
+  if (this.files.hasOwnProperty(file)) return;
+  this.files[file] = pos.content;
+};
+
+/**
+ * Applies any original source maps to the output.
+ */
+
+exports.applySourceMaps = function() {
+  for (var file in this.files) {
+    var originalMap = sourceMapResolve.resolveSync(
+      this.files[file], file, fs.readFileSync);
+    if (originalMap) {
+      originalMap = new SourceMapConsumer(originalMap.map);
+      this.map.applySourceMap(originalMap, file);
+    }
+  }
+};
+
+/**
+ * Process comments, drops sourceMap comments.
+ * @param {Object} node
+ */
+
+exports.comment = function(node) {
+  if (/^# sourceMappingURL=/.test(node.comment))
+    return this.emit('', node.position);
+  else
+    return this._comment(node);
 };

--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -97,7 +97,8 @@ exports.emit = function(str, pos, startOnly) {
 
 exports.addFile = function(pos) {
   var file = pos.source || 'source.css';
-  if (this.files.hasOwnProperty(file)) return;
+  if (Object.prototype.hasOwnProperty.call(this.files, file)) return;
+  if (typeof pos.content !== 'string') return;
   this.files[file] = pos.content;
 };
 
@@ -106,14 +107,14 @@ exports.addFile = function(pos) {
  */
 
 exports.applySourceMaps = function() {
-  for (var file in this.files) {
+  Object.keys(this.files).forEach(function(file) {
     var originalMap = sourceMapResolve.resolveSync(
       this.files[file], file, fs.readFileSync);
     if (originalMap) {
       originalMap = new SourceMapConsumer(originalMap.map);
       this.map.applySourceMap(originalMap, file);
     }
-  }
+  }, this);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "source-map": "~0.1.31"
+    "source-map": "~0.1.31",
+    "source-map-resolve": "^0.1.3"
   }
 }

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -67,4 +67,28 @@ describe('stringify(obj, {sourcemap: true})', function(){
     map.originalPositionFor({ line: 1, column: 50 }).should.eql(locs.mediaBlock);
     map.originalPositionFor({ line: 1, column: 64 }).should.eql(locs.mediaOnly);
   });
+
+  it('should apply included source maps', function(){
+    var file = 'test/source-map-apply.css';
+    var src = read(file, 'utf8');
+    var stylesheet = parse(src, { source: file, position: true });
+    var result = stringify(stylesheet, { sourcemap: true });
+    result.should.have.property('code');
+    result.should.have.property('map');
+
+    var map = new SourceMapConsumer(result.map);
+    map.originalPositionFor({ line: 1, column: 0 }).should.eql({
+      column: 0,
+      line: 1,
+      name: null,
+      source: 'source-map-apply.scss'
+    });
+
+    map.originalPositionFor({ line: 2, column: 2 }).should.eql({
+      column: 7,
+      line: 1,
+      name: null,
+      source: 'source-map-apply.scss'
+    });
+  });
 });

--- a/test/source-map-apply.css
+++ b/test/source-map-apply.css
@@ -1,0 +1,4 @@
+tobi {
+  name: 'tobi'; }
+
+/*# sourceMappingURL=source-map-apply.css.map */

--- a/test/source-map-apply.css.map
+++ b/test/source-map-apply.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "file": "",
+  "sources": ["source-map-apply.scss"],
+  "names": [],
+  "mappings": "AAAA;EAAO,MAAM"
+}

--- a/test/source-map-apply.scss
+++ b/test/source-map-apply.scss
@@ -1,0 +1,1 @@
+tobi { name: 'tobi'; }


### PR DESCRIPTION
This fixes #29, by searching all source files for any source maps that they contain and applying them to the output.

This depends on the currently unreleased master of css-parse.
