### PR TITLE
[WIP] Fix #39: Generate correct source paths

### DIFF
--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -7,6 +7,19 @@ var SourceMap = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var sourceMapResolve = require('source-map-resolve');
 var fs = require('fs');
+var path = require('path');
+
+/**
+ * Check if `filepath` is an absolute path.
+ *
+ * @param {String} filepath
+ * @return {Boolean}
+ * @api private
+ */
+
+function isAbsolute(filepath) {
+  return path.resolve(filepath) === path.normalize(filepath);
+}
 
 /**
  * Expose `mixin()`.
@@ -22,9 +35,14 @@ module.exports = mixin;
  */
 
 function mixin(compiler) {
-  var file = compiler.options.filename || 'generated.css';
+  var file = compiler.options.filename;
+  compiler.sourcemapDir = path.dirname(
+    typeof compiler.options.sourcemap === 'string'
+      ? compiler.options.sourcemap
+      : file || '.'
+  );
   compiler._comment = compiler.comment;
-  compiler.map = new SourceMap({ file: file });
+  compiler.map = new SourceMap({ file: file ? path.basename(file) : null });
   compiler.position = { line: 1, column: 1 };
   compiler.files = {};
   for (var k in exports) compiler[k] = exports[k];
@@ -56,6 +74,9 @@ exports.updatePosition = function(str) {
 
 exports.emit = function(str, pos, startOnly) {
   var sourceFile = pos && pos.source || 'source.css';
+  if (!isAbsolute(sourceFile)) {
+    sourceFile = path.relative(this.sourcemapDir, sourceFile);
+  }
 
   if (pos && pos.start) {
     this.map.addMapping({
@@ -115,8 +136,12 @@ exports.applySourceMaps = function() {
     var originalMap = sourceMapResolve.resolveSync(
       this.files[file], file, fs.readFileSync);
     if (originalMap) {
-      originalMap = new SourceMapConsumer(originalMap.map);
-      this.map.applySourceMap(originalMap, file);
+      var map = new SourceMapConsumer(originalMap.map);
+      var relativeTo = originalMap.sourcesRelativeTo;
+      if (!isAbsolute(relativeTo)) {
+        relativeTo = path.relative(this.sourcemapDir, relativeTo);
+      }
+      this.map.applySourceMap(map, file, path.dirname(relativeTo));
     }
   }, this);
 };

--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -6,20 +6,10 @@
 var SourceMap = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var sourceMapResolve = require('source-map-resolve');
+var urix = require('urix');
 var fs = require('fs');
 var path = require('path');
-
-/**
- * Check if `filepath` is an absolute path.
- *
- * @param {String} filepath
- * @return {Boolean}
- * @api private
- */
-
-function isAbsolute(filepath) {
-  return path.resolve(filepath) === path.normalize(filepath);
-}
+var url = require('url');
 
 /**
  * Expose `mixin()`.
@@ -36,17 +26,27 @@ module.exports = mixin;
 
 function mixin(compiler) {
   var file = compiler.options.filename;
-  compiler.sourcemapDir = path.dirname(
-    typeof compiler.options.sourcemap === 'string'
-      ? compiler.options.sourcemap
-      : file || '.'
-  );
+  compiler.sourcemapPath = typeof compiler.options.sourcemap === 'string'
+    ? compiler.options.sourcemap
+    : file || '.';
   compiler._comment = compiler.comment;
   compiler.map = new SourceMap({ file: file ? path.basename(file) : null });
   compiler.position = { line: 1, column: 1 };
   compiler.files = {};
   for (var k in exports) compiler[k] = exports[k];
 }
+
+/**
+ * Convert `filepath` to a URL, relative to `this.sourcemapPath`.
+ *
+ * @param {String} filepath
+ * @return {String}
+ * @api private
+ */
+
+exports.relativeUrl = function(filepath) {
+  return url.resolve(urix(this.sourcemapPath), urix(filepath))
+};
 
 /**
  * Update position.
@@ -73,10 +73,7 @@ exports.updatePosition = function(str) {
  */
 
 exports.emit = function(str, pos, startOnly) {
-  var sourceFile = pos && pos.source || 'source.css';
-  if (!isAbsolute(sourceFile)) {
-    sourceFile = path.relative(this.sourcemapDir, sourceFile);
-  }
+  var sourceFile = this.relativeUrl(pos && pos.source || 'source.css');
 
   if (pos && pos.start) {
     this.map.addMapping({
@@ -137,11 +134,8 @@ exports.applySourceMaps = function() {
       this.files[file], file, fs.readFileSync);
     if (originalMap) {
       var map = new SourceMapConsumer(originalMap.map);
-      var relativeTo = originalMap.sourcesRelativeTo;
-      if (!isAbsolute(relativeTo)) {
-        relativeTo = path.relative(this.sourcemapDir, relativeTo);
-      }
-      this.map.applySourceMap(map, file, path.dirname(relativeTo));
+      var relativeTo = this.relativeUrl(path.dirname(originalMap.sourcesRelativeTo));
+      this.map.applySourceMap(map, file, relativeTo);
     }
   }, this);
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "source-map": "~0.1.31",
-    "source-map-resolve": "^0.1.3"
+    "source-map-resolve": "^0.1.3",
+    "urix": "~0.1.0"
   }
 }

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -81,14 +81,14 @@ describe('stringify(obj, {sourcemap: true})', function(){
       column: 0,
       line: 1,
       name: null,
-      source: 'source-map-apply.scss'
+      source: 'test/source-map-apply.scss'
     });
 
     map.originalPositionFor({ line: 2, column: 2 }).should.eql({
       column: 7,
       line: 1,
       name: null,
-      source: 'source-map-apply.scss'
+      source: 'test/source-map-apply.scss'
     });
   });
 });


### PR DESCRIPTION
- Allow `options.filename` to be a path to the intended output file (not
  just the basename of it).
- Set the `file` property of the source map to the basename of
  `options.filename`, or don’t set it at all if `options.filename` was
  omitted.
- Allow `options.sourcemap` to be a string: The path to the intended
  location of the source map. If relative, it is relative to the current
  working directory. (Only the dirname of `options.sourcemap` is used.)
- If `options.sourcemap` is set to `true`, assume that the source map is
  intended to either be placed next to `options.filename`, or be inlined
  into the CSS as a data uri, by using the dirname of `options.filename`
  or the current working directory if `options.filename` was omitted
  (instead of using the dirname of `options.sourcemap` as in the above
  bullet point).
- Make relative source paths relative to the source map directory before
  adding them to the source map.
- Make relative source paths from applied original maps relative to the
  source map directory before adding them to the map.
  ---
  
  TODO: Tests and docs.
