### PR TITLE
Make relative applied source paths relative to CWD

### DIFF
--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -107,6 +107,17 @@ exports.addFile = function(pos) {
 };
 
 /**
+ * Returns the dirname of a URL.
+ * @param {String} url
+ * @return {String}
+ * @api private
+ */
+
+function dirname(url) {
+  return url.replace(/\/?[^/]+$/, '') || '.';
+}
+
+/**
  * Applies any original source maps to the output.
  */
 
@@ -115,8 +126,9 @@ exports.applySourceMaps = function() {
     var originalMap = sourceMapResolve.resolveSync(
       this.files[file], file, fs.readFileSync);
     if (originalMap) {
-      originalMap = new SourceMapConsumer(originalMap.map);
-      this.map.applySourceMap(originalMap, file);
+      var map = new SourceMapConsumer(originalMap.map);
+      var relativeTo = originalMap.sourcesRelativeTo;
+      this.map.applySourceMap(map, file, dirname(relativeTo));
     }
   }, this);
 };

--- a/test/css-stringify.js
+++ b/test/css-stringify.js
@@ -68,7 +68,7 @@ describe('stringify(obj, {sourcemap: true})', function(){
     map.originalPositionFor({ line: 1, column: 64 }).should.eql(locs.mediaOnly);
   });
 
-  it('should apply included source maps', function(){
+  it('should apply included source maps, with source paths relative to CWD', function(){
     var file = 'test/source-map-apply.css';
     var src = read(file, 'utf8');
     var stylesheet = parse(src, { source: file, position: true });
@@ -81,14 +81,14 @@ describe('stringify(obj, {sourcemap: true})', function(){
       column: 0,
       line: 1,
       name: null,
-      source: 'source-map-apply.scss'
+      source: 'test/source-map-apply.scss'
     });
 
     map.originalPositionFor({ line: 2, column: 2 }).should.eql({
       column: 7,
       line: 1,
       name: null,
-      source: 'source-map-apply.scss'
+      source: 'test/source-map-apply.scss'
     });
   });
 });


### PR DESCRIPTION
When generating a source map, the paths put into the `sources` array of
the source map normally come from `pos.source` properties on the AST
nodes. These are today assumed to be relative to the current working
directory, since that’s how any original source maps are resolved and
applied.

Paths in the `sources` array can also come from applied original maps.
Relative such source paths are relative to the original source map --
not to the current working directory!

It does not make sense to mix paths that are relative to different
things. Therefore this commit makes sure that applied relative source
maps are rewritten to be relative to the current working directory, like
all other sources.

An existing test was updated to test this.
