### PR TITLE
Deprecate the `filename` option

### DIFF
--- a/lib/source-map-support.js
+++ b/lib/source-map-support.js
@@ -22,9 +22,14 @@ module.exports = mixin;
  */
 
 function mixin(compiler) {
-  var file = compiler.options.filename || 'generated.css';
+  if ('filename' in compiler.options) {
+    console.warn('The `filename` option has been deprecated. Set the `file` ' +
+        'property on the returned source map object instead.');
+    compiler.map = new SourceMap({ file: compiler.options.filename });
+  } else {
+    compiler.map = new SourceMap();
+  }
   compiler._comment = compiler.comment;
-  compiler.map = new SourceMap({ file: file });
   compiler.position = { line: 1, column: 1 };
   compiler.files = {};
   for (var k in exports) compiler[k] = exports[k];


### PR DESCRIPTION
Why?
- It is only used to set the `file` property of the source map, and
  that’s probably done just because the `file` property used to be a
  required property of source maps. It isn’t no more.
- The `file` property is not used by browsers.
- The user could easily just add the property himself on the returned
  source map object.
- It was neither documented nor tested.
- KISS.
